### PR TITLE
Added error callback to preview

### DIFF
--- a/src/Our.Umbraco.BlockTypeGridViewPreview/App_Plugins/Our.Umbraco.BlockTypeGridViewPreview/BlockTypeGridViewPreviewController.js
+++ b/src/Our.Umbraco.BlockTypeGridViewPreview/App_Plugins/Our.Umbraco.BlockTypeGridViewPreview/BlockTypeGridViewPreviewController.js
@@ -45,6 +45,17 @@ angular.module("umbraco").controller("BlockTypeGridViewPreviewController", [
                 if (htmlResult.trim().length > 0) {
                     $scope.preview = htmlResult;
                 }
+            },
+            function (response) {
+                $scope.preview = "<b>Preview not available for this block</b>";
+
+                if (umbraoUser.user && umbraoUser.user.userGroups.indexOf("admin")>=0) {
+                    if (response.statusText)
+                        $scope.preview += "<br/><small>" + response.statusText + "</small>";
+
+                    if (response.data && response.data.ExceptionMessage)
+                        $scope.preview += " - <small> " + response.data.ExceptionMessage + "</small>";
+                }
             });
         };
 


### PR DESCRIPTION
When the preview post method throws an error and has no content to render, the block list editor will not show any content.
The block will not be visible in the backoffice for editors but it will exist, causing errors on the published page or cluttering the database with "hidden" blocks of data.

This commit adds an onError callback to the $http method showing a message when rendering failed, allowing admins to edit or remove the block.

Code courtesy of @gerbenvd 