### PR TITLE
Add support for nested block editors

### DIFF
--- a/src/Our.Umbraco.BlockTypeGridViewPreview/App_Plugins/Our.Umbraco.BlockTypeGridViewPreview/BlockTypeGridViewPreviewController.js
+++ b/src/Our.Umbraco.BlockTypeGridViewPreview/App_Plugins/Our.Umbraco.BlockTypeGridViewPreview/BlockTypeGridViewPreviewController.js
@@ -8,8 +8,10 @@ angular.module("umbraco").controller("BlockTypeGridViewPreviewController", [
     function ($scope, editorState, $http) {
 
         let model = $scope.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.model;
+        let nestedModel = $scope.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.$parent.vm;
         let currentState = angular.copy(editorState.current);
         let propertyAlias = model.alias;
+        let nestedContentTypeAlias = nestedModel != null ? nestedModel.model.contentTypeAlias : null;
         let editorAlias = model.editor;
 
 
@@ -35,6 +37,7 @@ angular.module("umbraco").controller("BlockTypeGridViewPreviewController", [
                     pageId: currentState.id,
                     propertyAlias: propertyAlias,
                     contentTypeAlias: currentState.contentTypeAlias,
+                    nestedContentTypeAlias: nestedContentTypeAlias,
                     value: JSON.stringify(value)
                 }),
                 headers: {

--- a/src/Our.Umbraco.BlockTypeGridViewPreview/Controllers/PreviewController.cs
+++ b/src/Our.Umbraco.BlockTypeGridViewPreview/Controllers/PreviewController.cs
@@ -51,6 +51,14 @@ namespace Our.Umbraco.BlockTypeGridViewPreview.Controllers
             var publishedContentType = new Lazy<IPublishedContentType>(() => _publishedContentTypeFactory.CreateContentType(contentType)).Value;
             var propertyType = publishedContentType.PropertyTypes.FirstOrDefault(x => x.Alias == data.PropertyAlias);
 
+            // If it's null, it's likely we're looking at a nested block editor
+            if (propertyType == null)
+            {
+                contentType = Services.ContentTypeService.Get(data.NestedContentTypeAlias);
+                publishedContentType = new Lazy<IPublishedContentType>(() => _publishedContentTypeFactory.CreateContentType(contentType)).Value;
+                propertyType = publishedContentType.PropertyTypes.FirstOrDefault(x => x.Alias == data.PropertyAlias);
+            }
+
             var editor = new BlockListPropertyValueConverter(
                 _profilingLogger,
                 new BlockEditorConverter(_publishedSnapshotAccessor, _publishedModelFactory));

--- a/src/Our.Umbraco.BlockTypeGridViewPreview/Models/BlockPreview.cs
+++ b/src/Our.Umbraco.BlockTypeGridViewPreview/Models/BlockPreview.cs
@@ -17,5 +17,8 @@ namespace Our.Umbraco.BlockTypeGridViewPreview.Models
 
         [DataMember(Name = "value")]
         public string Value { get; set; }
+
+        [DataMember(Name = "nestedContentTypeAlias")]
+        public string NestedContentTypeAlias { get; set; }
     }
 }


### PR DESCRIPTION
As the title says, this adds support to preview nested block list properties.

It goes back up the parent scope in the JS to get the `contentTypeAlias` of the block, then passes that alias to the `PreviewController`